### PR TITLE
feat: v1.1.0 — support modern MediaPipe Tasks API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,10 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Auto-downloaded MediaPipe face landmarker model (~3.7 MB).
+# Cached on first run by head_orientation_node.py.
+models/face_landmarker.task
+
+# Local smoke tests (not shipped to users)
+_smoke_test.py

--- a/README.md
+++ b/README.md
@@ -1,72 +1,114 @@
-## Head Orientation Node Update version = "1.0.11"
-
-### New Data Output Format
-
-The Head Orientation Node now provides a string output named "data" alongside the sorted images. This output contains information about the head orientation for each processed image.
-
-#### Format Details:
-- Each line in the output represents one image's head orientation.
-- The format for each line is `[x,y,z]`, where:
-  - `x`: Rotation around the X-axis (nodding up and down)
-  - `y`: Rotation around the Y-axis (turning left and right)
-  - `z`: Rotation around the Z-axis (tilting head side to side)
-- All values are in degrees and rounded to two decimal places.
-- Each orientation is on a new line.
-
-#### Example Output:
-
 # Head Orientation Node for ComfyUI
 
-## Description
+Version **1.1.0** — by **PabloGFX**
 
-The Head Orientation Node is a custom node for ComfyUI that analyzes and sorts images based on head orientation. It uses the MediaPipe library to detect facial landmarks and calculate head pose, allowing for intelligent image sorting and matching.
+A custom ComfyUI node that detects faces, estimates head pose (pitch / yaw /
+roll), and sorts a batch of input images so that the i-th input best matches
+the head orientation of the i-th reference image.
 
-Developed by PabloGFX, this node enhances ComfyUI's capabilities in facial analysis and image processing tasks.
+## What's new in 1.1.0
+
+- **Compatibility with modern MediaPipe (>=0.10).** Earlier versions of this
+  node relied on `mediapipe.solutions.face_mesh`, which is no longer present in
+  the slimmed-down `mediapipe` builds shipped with recent Python embeds (e.g.
+  the ComfyUI Windows portable). The node now uses the new
+  `mediapipe.tasks.python.vision.FaceLandmarker` API and falls back to the
+  legacy `solutions.face_mesh` API if it is available — so the same code works
+  on old and new MediaPipe installations.
+- **Automatic model download.** On first use the node downloads the official
+  Google-hosted `face_landmarker.task` model (~3.7 MB) into
+  `head-orientation-node/models/` and reuses it afterwards. No manual setup is
+  required.
+- **More robust image handling.** Correct RGB handling (the legacy code
+  unintentionally swapped R and B channels via an extra `cvtColor` call),
+  graceful handling of grayscale and RGBA inputs, and safer batch sorting when
+  no input images are provided.
+- **Better diagnostics.** The node prints the MediaPipe backend it is using
+  (`legacy` vs. `tasks`) and reports model-download progress.
+
+## Data output format
+
+The node returns two outputs:
+
+1. `sorted_images` — the input batch reordered to best match the reference
+   batch.
+2. `data` — a multi-line string where each line is the head orientation of one
+   sorted output image in the form `[x,y,z]`, where:
+   - `x` — rotation around the X-axis (pitch, nodding up/down)
+   - `y` — rotation around the Y-axis (yaw, turning left/right)
+   - `z` — rotation around the Z-axis (roll, tilting side to side)
+
+All values are in degrees, rounded to two decimal places, one orientation per
+line.
 
 ## Features
 
-- Detects facial landmarks using MediaPipe
-- Calculates head orientation (pitch, yaw, roll) for input images
-- Sorts input images based on similarity to reference images' head orientations
-- Supports batch processing of multiple images
+- Detects facial landmarks with MediaPipe (new Tasks API or legacy face_mesh).
+- Estimates head orientation (pitch, yaw, roll) for every image in a batch.
+- Sorts the input batch by similarity to a reference batch (greedy 3D-angle
+  match).
+- Handles batches of arbitrary size, with safe fallbacks when there are fewer
+  inputs than references.
 
 ## Installation
 
-1. Ensure you have ComfyUI installed and set up.
-2. Clone this repository into your ComfyUI custom nodes directory:
+1. Clone this repository into your ComfyUI `custom_nodes` directory:
+   ```bash
+   git clone https://github.com/lazniak/Head-Orientation-Node-for-ComfyUI---by-PabloGFX.git
    ```
-   git clone https://github.com/YourGitHubUsername/head-orientation-node.git
-   ```
-3. Install the required dependencies:
-   ```
+2. Install the required dependencies (use the Python that runs ComfyUI — for
+   the Windows portable that is `python_embeded\python.exe`):
+   ```bash
    pip install -r requirements.txt
    ```
+3. Restart ComfyUI. The first run will download
+   `models/face_landmarker.task` automatically.
 
 ## Requirements
 
-- numpy>=1.19.3
-- opencv-python>=4.5.5.64
-- mediapipe>=0.8.9.1
-- Pillow>=8.3.1
-- torch>=1.9.0
+- numpy >= 1.19.3
+- opencv-python >= 4.5.5.64
+- mediapipe >= 0.10.0
+- Pillow >= 8.3.1
+- torch >= 1.9.0
 
 ## Usage
 
-1. In ComfyUI, you'll find the node listed as "Head Orientation Node - by PabloGFX" in the node browser.
-2. Connect an image or batch of images to the "image" input.
-3. Connect a set of reference images to the "reference_images" input.
-4. The node will output a sorted batch of images based on head orientation similarity to the reference images.
+1. In ComfyUI, locate the node in the browser as **Head Orientation Node - by
+   PabloGFX** (category `image/PabloGFX`).
+2. Connect a batch of images to `image`.
+3. Connect a reference batch to `reference_images`.
+4. The node outputs the input batch reordered to best match the orientations of
+   the reference batch, together with the per-image orientation string.
 
-## How it Works
+## How it works
 
-1. The node analyzes both input and reference images using MediaPipe's face mesh detection.
-2. It calculates the head orientation (pitch, yaw, roll) for each detected face.
-3. Input images are then sorted to best match the orientations of the reference images.
-4. If there are fewer input images than reference images, the last input image is repeated to match the count.
+1. For each image the node converts the ComfyUI tensor to an `RGB uint8` image
+   and runs MediaPipe face landmark detection.
+2. Six canonical landmarks (eyes, nose, mouth corners, chin) are fed into
+   OpenCV's `solvePnP` together with a simple pinhole camera model to recover
+   the head rotation, which is decomposed into pitch / yaw / roll.
+3. Each reference orientation is greedily matched to the closest unused input
+   orientation by Euclidean distance in (pitch, yaw, roll) space.
+4. If there are fewer inputs than references, the last matched input is
+   repeated to keep the batch sizes aligned.
+
+## Notes about the MediaPipe model
+
+The first run downloads the official Google-hosted face landmarker model from:
+
+```
+https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task
+```
+
+It is cached at `head-orientation-node/models/face_landmarker.task`. If your
+ComfyUI installation cannot reach the internet, drop the file there manually
+before using the node.
 
 ## License
 
-This project is licensed under the Apache License 2.0. This license is compatible with the licenses of the major dependencies used in this project:
+This project is licensed under the Apache License 2.0. This license is
+compatible with the licenses of the major dependencies used in this project:
 
 - MediaPipe: Apache License 2.0
 - OpenCV: Apache License 2.0
@@ -74,15 +116,17 @@ This project is licensed under the Apache License 2.0. This license is compatibl
 - PyTorch: BSD 3-Clause License
 - Pillow: HPND License
 
-The Apache License 2.0 allows you to use, modify, distribute, and sublicense the code, while also providing an express grant of patent rights from contributors to users. It requires preservation of copyright and license notices.
-
-For the full license text, please see the LICENSE file in the project repository or visit: https://www.apache.org/licenses/LICENSE-2.0
+The Apache License 2.0 allows you to use, modify, distribute, and sublicense
+the code, while also providing an express grant of patent rights from
+contributors to users. It requires preservation of copyright and license
+notices. For the full license text see the `LICENSE` file or
+https://www.apache.org/licenses/LICENSE-2.0.
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request. By contributing to this project, you agree to license your contributions under the Apache License 2.0.
+Contributions are welcome. By contributing to this project you agree to
+license your contributions under the Apache License 2.0.
 
 ## Acknowledgements
 
-Special thanks to the developers of MediaPipe, OpenCV, and other open-source libraries that made this project possible.
-
+Thanks to the developers of MediaPipe, OpenCV, NumPy, PyTorch and Pillow.

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,6 @@
-from .head_orientation_node import HeadOrientationNode
+from .head_orientation_node import (
+    NODE_CLASS_MAPPINGS,
+    NODE_DISPLAY_NAME_MAPPINGS,
+)
 
-NODE_CLASS_MAPPINGS = {
-    "HeadOrientationNode": HeadOrientationNode,
-}
-
-NODE_DISPLAY_NAME_MAPPINGS = {
-    "HeadOrientationNode": "Head Orientation Node - by PabloGFX",
-}
-
-__all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS']
+__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]

--- a/head_orientation_node.py
+++ b/head_orientation_node.py
@@ -1,9 +1,25 @@
-import torch
-import numpy as np
+"""Head Orientation Node for ComfyUI - by PabloGFX.
+
+Detects faces in a batch of images, estimates head pose (pitch/yaw/roll) and
+sorts the input batch so the i-th input best matches the orientation of the
+i-th reference image.
+
+This module supports both the new MediaPipe Tasks API (>=0.10) and the
+legacy `mediapipe.solutions.face_mesh` API for maximum compatibility.
+"""
+
+import os
+import urllib.request
+from typing import List, Optional, Tuple
+
 import cv2
+import numpy as np
+import torch
+
 import mediapipe as mp
 
-# Definicje kolorów ANSI
+
+# ANSI colors for log output
 class Colors:
     HEADER = '\033[95m'
     BLUE = '\033[94m'
@@ -14,9 +30,173 @@ class Colors:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
+
+# Landmark indices used for PnP head-pose estimation (canonical face mesh):
+#   33  - right eye outer corner
+#   263 - left eye outer corner
+#   1   - nose tip
+#   61  - right mouth corner
+#   291 - left mouth corner
+#   199 - chin
+PNP_LANDMARK_INDICES = (33, 263, 1, 61, 291, 199)
+
+# Official Google-hosted MediaPipe face landmarker model (float16, ~3.7 MB).
+FACE_LANDMARKER_MODEL_URL = (
+    "https://storage.googleapis.com/mediapipe-models/face_landmarker/"
+    "face_landmarker/float16/1/face_landmarker.task"
+)
+FACE_LANDMARKER_MODEL_FILENAME = "face_landmarker.task"
+
+
+def _plugin_model_dir() -> str:
+    """Returns the directory where the face landmarker model is cached."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(here, "models")
+
+
+def _ensure_face_landmarker_model() -> str:
+    """Downloads the MediaPipe face landmarker model on first use.
+
+    Returns the absolute path to the .task model file.
+    """
+    model_dir = _plugin_model_dir()
+    os.makedirs(model_dir, exist_ok=True)
+    model_path = os.path.join(model_dir, FACE_LANDMARKER_MODEL_FILENAME)
+
+    if os.path.isfile(model_path) and os.path.getsize(model_path) > 0:
+        return model_path
+
+    print(
+        f"{Colors.YELLOW}[HeadOrientationNode] Downloading MediaPipe face "
+        f"landmarker model to {model_path} ...{Colors.ENDC}"
+    )
+    try:
+        urllib.request.urlretrieve(FACE_LANDMARKER_MODEL_URL, model_path)
+    except Exception as exc:
+        if os.path.isfile(model_path):
+            try:
+                os.remove(model_path)
+            except OSError:
+                pass
+        raise RuntimeError(
+            f"Failed to download MediaPipe face landmarker model from "
+            f"{FACE_LANDMARKER_MODEL_URL}: {exc}"
+        ) from exc
+
+    print(
+        f"{Colors.GREEN}[HeadOrientationNode] Model downloaded "
+        f"({os.path.getsize(model_path)/1024:.1f} KB).{Colors.ENDC}"
+    )
+    return model_path
+
+
+def _has_legacy_solutions() -> bool:
+    """Returns True if the installed mediapipe exposes the legacy solutions API."""
+    return hasattr(mp, "solutions") and hasattr(mp.solutions, "face_mesh")
+
+
+def _has_tasks_api() -> bool:
+    """Returns True if mediapipe.tasks vision FaceLandmarker is importable."""
+    try:
+        from mediapipe.tasks.python import vision as _vision  # noqa: F401
+        return hasattr(_vision, "FaceLandmarker")
+    except Exception:
+        return False
+
+
+class _FaceDetector:
+    """Thin adapter that hides the differences between the legacy
+    `solutions.face_mesh` API and the new `tasks.python.vision.FaceLandmarker`
+    API. Exposes a single `process(rgb_uint8)` -> Optional[list of (x, y, z)
+    normalized landmarks] method.
+    """
+
+    def __init__(self, max_num_faces: int = 1, min_detection_confidence: float = 0.5):
+        self._mode: str
+        self._impl = None
+        self._max_num_faces = max_num_faces
+        self._min_detection_confidence = min_detection_confidence
+
+        # Prefer legacy when available (it keeps behavior identical to older
+        # versions of this node). Fall back to the new Tasks API otherwise.
+        if _has_legacy_solutions():
+            self._mode = "legacy"
+            face_mesh_module = mp.solutions.face_mesh
+            self._impl = face_mesh_module.FaceMesh(
+                static_image_mode=True,
+                max_num_faces=max_num_faces,
+                min_detection_confidence=min_detection_confidence,
+            )
+            print(
+                f"{Colors.HEADER}[HeadOrientationNode] Using legacy "
+                f"mediapipe.solutions.face_mesh (v{mp.__version__}){Colors.ENDC}"
+            )
+        elif _has_tasks_api():
+            self._mode = "tasks"
+            from mediapipe.tasks import python as mp_python
+            from mediapipe.tasks.python import vision as mp_vision
+
+            model_path = _ensure_face_landmarker_model()
+            base_options = mp_python.BaseOptions(model_asset_path=model_path)
+            options = mp_vision.FaceLandmarkerOptions(
+                base_options=base_options,
+                running_mode=mp_vision.RunningMode.IMAGE,
+                num_faces=max_num_faces,
+                min_face_detection_confidence=min_detection_confidence,
+                min_face_presence_confidence=min_detection_confidence,
+                min_tracking_confidence=min_detection_confidence,
+            )
+            self._impl = mp_vision.FaceLandmarker.create_from_options(options)
+            print(
+                f"{Colors.HEADER}[HeadOrientationNode] Using mediapipe Tasks "
+                f"FaceLandmarker (v{mp.__version__}){Colors.ENDC}"
+            )
+        else:
+            raise RuntimeError(
+                "Installed mediapipe (v{ver}) exposes neither the legacy "
+                "`solutions.face_mesh` API nor the new "
+                "`tasks.python.vision.FaceLandmarker` API. Please install "
+                "mediapipe>=0.10 with `pip install -U mediapipe`.".format(
+                    ver=getattr(mp, "__version__", "?")
+                )
+            )
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    def process(self, image_rgb_uint8: np.ndarray) -> Optional[List[Tuple[float, float, float]]]:
+        """Runs face detection on a single HxWx3 uint8 RGB image.
+
+        Returns a list of (x_norm, y_norm, z_norm) tuples for the first
+        detected face, or None if no face was found.
+        """
+        if self._mode == "legacy":
+            results = self._impl.process(image_rgb_uint8)
+            if not getattr(results, "multi_face_landmarks", None):
+                return None
+            face = results.multi_face_landmarks[0]
+            return [(lm.x, lm.y, lm.z) for lm in face.landmark]
+
+        # Tasks API
+        mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=image_rgb_uint8)
+        result = self._impl.detect(mp_image)
+        if not getattr(result, "face_landmarks", None):
+            return None
+        face = result.face_landmarks[0]
+        return [(lm.x, lm.y, lm.z) for lm in face]
+
+    def close(self) -> None:
+        try:
+            if self._impl is not None and hasattr(self._impl, "close"):
+                self._impl.close()
+        except Exception:
+            pass
+
+
 class HeadOrientationNode:
     @classmethod
-    def INPUT_TYPES(s):
+    def INPUT_TYPES(cls):
         return {
             "required": {
                 "image": ("IMAGE",),
@@ -30,9 +210,18 @@ class HeadOrientationNode:
     CATEGORY = "image/PabloGFX"
 
     def __init__(self):
-        self.mp_face_mesh = mp.solutions.face_mesh
-        self.face_mesh = self.mp_face_mesh.FaceMesh(static_image_mode=True, min_detection_confidence=0.5, max_num_faces=1)
-        print(f"{Colors.HEADER}HeadOrientationNode initialized{Colors.ENDC}")
+        self._detector = _FaceDetector(max_num_faces=1, min_detection_confidence=0.5)
+        print(
+            f"{Colors.HEADER}HeadOrientationNode initialized "
+            f"(mode={self._detector.mode}){Colors.ENDC}"
+        )
+
+    def __del__(self):
+        try:
+            if getattr(self, "_detector", None) is not None:
+                self._detector.close()
+        except Exception:
+            pass
 
     def process_images(self, image, reference_images):
         print(f"{Colors.BLUE}[PROCESS] Input image shape: {image.shape}, dtype: {image.dtype}{Colors.ENDC}")
@@ -52,68 +241,97 @@ class HeadOrientationNode:
         print(f"{Colors.GREEN}[PROCESS] Output data: \n{data_output}{Colors.ENDC}")
         return (sorted_images, data_output)
 
-    def analyze_orientations(self, images):
+    def analyze_orientations(self, images: torch.Tensor) -> List[Tuple[float, float, float]]:
         print(f"{Colors.BLUE}[ANALYZE] Starting analysis of {images.shape[0]} images{Colors.ENDC}")
-        orientations = []
+        orientations: List[Tuple[float, float, float]] = []
+
         for idx in range(images.shape[0]):
             print(f"{Colors.YELLOW}[ANALYZE] Processing image {idx+1}/{images.shape[0]}{Colors.ENDC}")
-            img = images[idx].cpu().numpy()
-            print(f"{Colors.BLUE}[ANALYZE] Image {idx+1} shape: {img.shape}, dtype: {img.dtype}{Colors.ENDC}")
-            
-            if img.shape[0] == 3:
-                print(f"{Colors.YELLOW}[ANALYZE] Image {idx+1} is in CHW format, transposing to HWC{Colors.ENDC}")
+            img = images[idx].detach().cpu().numpy()
+            print(f"{Colors.BLUE}[ANALYZE] Image {idx+1} raw shape: {img.shape}, dtype: {img.dtype}{Colors.ENDC}")
+
+            # Normalize layout to HWC.
+            if img.ndim == 3 and img.shape[0] in (1, 3, 4) and img.shape[-1] not in (1, 3, 4):
+                print(f"{Colors.YELLOW}[ANALYZE] Image {idx+1} is CHW, transposing to HWC{Colors.ENDC}")
                 img = np.transpose(img, (1, 2, 0))
-            
-            img = (img * 255).astype(np.uint8)
-            print(f"{Colors.BLUE}[ANALYZE] Image {idx+1} converted to uint8, shape: {img.shape}, dtype: {img.dtype}{Colors.ENDC}")
-            
-            if img.shape[2] > 3:
-                print(f"{Colors.YELLOW}[ANALYZE] Image {idx+1} has {img.shape[2]} channels, using only first 3{Colors.ENDC}")
+
+            # ComfyUI IMAGE tensors are float32 in [0, 1]. Convert to uint8 RGB.
+            if img.dtype != np.uint8:
+                img = np.clip(img, 0.0, 1.0)
+                img = (img * 255.0 + 0.5).astype(np.uint8)
+
+            if img.ndim == 2:
+                img = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
+            elif img.shape[2] == 1:
+                img = cv2.cvtColor(img[:, :, 0], cv2.COLOR_GRAY2RGB)
+            elif img.shape[2] >= 4:
+                print(f"{Colors.YELLOW}[ANALYZE] Image {idx+1} has {img.shape[2]} channels, dropping alpha{Colors.ENDC}")
                 img = img[:, :, :3]
-            
-            print(f"{Colors.YELLOW}[ANALYZE] Converting image {idx+1} to RGB{Colors.ENDC}")
-            image_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-            print(f"{Colors.YELLOW}[ANALYZE] Processing image {idx+1} with MediaPipe{Colors.ENDC}")
-            results = self.face_mesh.process(image_rgb)
 
-            if results.multi_face_landmarks:
-                print(f"{Colors.GREEN}[ANALYZE] Face detected in image {idx+1}{Colors.ENDC}")
-                face_landmarks = results.multi_face_landmarks[0]
-                face_3d = []
-                face_2d = []
-                for lmk_idx, lm in enumerate(face_landmarks.landmark):
-                    if lmk_idx in [33, 263, 1, 61, 291, 199]:
-                        x, y = int(lm.x * img.shape[1]), int(lm.y * img.shape[0])
-                        face_3d.append([x, y, lm.z])
-                        face_2d.append([x, y])
+            # MediaPipe expects RGB uint8 - ComfyUI tensors are already RGB.
+            img = np.ascontiguousarray(img)
+            h, w = img.shape[:2]
 
-                face_3d = np.array(face_3d, dtype=np.float64)
-                face_2d = np.array(face_2d, dtype=np.float64)
+            print(f"{Colors.YELLOW}[ANALYZE] Detecting face in image {idx+1} ({w}x{h}){Colors.ENDC}")
+            landmarks = self._detector.process(img)
 
-                focal_length = 1 * img.shape[1]
-                cam_matrix = np.array([[focal_length, 0, img.shape[0] / 2],
-                                       [0, focal_length, img.shape[1] / 2],
-                                       [0, 0, 1]])
-                dist_matrix = np.zeros((4, 1), dtype=np.float64)
-
-                print(f"{Colors.YELLOW}[ANALYZE] Calculating head pose for image {idx+1}{Colors.ENDC}")
-                success, rot_vec, _ = cv2.solvePnP(face_3d, face_2d, cam_matrix, dist_matrix)
-                rmat, _ = cv2.Rodrigues(rot_vec)
-                angles, _, _, _, _, _ = cv2.RQDecomp3x3(rmat)
-                x, y, z = angles[0] * 360, angles[1] * 360, angles[2] * 360
-                orientations.append((x, y, z))
-                print(f"{Colors.GREEN}[ANALYZE] Image {idx+1}: Orientation calculated - (x: {x:.2f}, y: {y:.2f}, z: {z:.2f}){Colors.ENDC}")
-            else:
+            if landmarks is None:
                 print(f"{Colors.RED}[ANALYZE] No face detected in image {idx+1}{Colors.ENDC}")
-                orientations.append((0, 0, 0))
+                orientations.append((0.0, 0.0, 0.0))
+                continue
+
+            face_2d: List[List[float]] = []
+            face_3d: List[List[float]] = []
+            for lmk_idx in PNP_LANDMARK_INDICES:
+                if lmk_idx >= len(landmarks):
+                    continue
+                lx, ly, lz = landmarks[lmk_idx]
+                x_px, y_px = float(lx * w), float(ly * h)
+                face_2d.append([x_px, y_px])
+                face_3d.append([x_px, y_px, float(lz)])
+
+            if len(face_2d) < 4:
+                print(f"{Colors.RED}[ANALYZE] Not enough landmarks for PnP in image {idx+1}{Colors.ENDC}")
+                orientations.append((0.0, 0.0, 0.0))
+                continue
+
+            face_2d_np = np.asarray(face_2d, dtype=np.float64)
+            face_3d_np = np.asarray(face_3d, dtype=np.float64)
+
+            focal_length = float(w)
+            cam_matrix = np.array(
+                [
+                    [focal_length, 0.0, w / 2.0],
+                    [0.0, focal_length, h / 2.0],
+                    [0.0, 0.0, 1.0],
+                ],
+                dtype=np.float64,
+            )
+            dist_matrix = np.zeros((4, 1), dtype=np.float64)
+
+            print(f"{Colors.YELLOW}[ANALYZE] Calculating head pose for image {idx+1}{Colors.ENDC}")
+            success, rot_vec, _ = cv2.solvePnP(face_3d_np, face_2d_np, cam_matrix, dist_matrix)
+            if not success:
+                print(f"{Colors.RED}[ANALYZE] solvePnP failed for image {idx+1}{Colors.ENDC}")
+                orientations.append((0.0, 0.0, 0.0))
+                continue
+
+            rmat, _ = cv2.Rodrigues(rot_vec)
+            angles, _, _, _, _, _ = cv2.RQDecomp3x3(rmat)
+            x_deg, y_deg, z_deg = angles[0] * 360.0, angles[1] * 360.0, angles[2] * 360.0
+            orientations.append((x_deg, y_deg, z_deg))
+            print(
+                f"{Colors.GREEN}[ANALYZE] Image {idx+1}: "
+                f"pitch={x_deg:.2f}, yaw={y_deg:.2f}, roll={z_deg:.2f}{Colors.ENDC}"
+            )
 
         print(f"{Colors.GREEN}[ANALYZE] Analysis completed for {len(orientations)} images{Colors.ENDC}")
         return orientations
 
     def sort_images(self, images, input_orientations, reference_orientations):
         print(f"{Colors.BLUE}[SORT] Sorting {len(input_orientations)} input images based on {len(reference_orientations)} reference orientations{Colors.ENDC}")
-        sorted_indices = []
-        sorted_orientations = []
+        sorted_indices: List[int] = []
+        sorted_orientations: List[Tuple[float, float, float]] = []
         used_indices = set()
 
         for ref_idx, ref_orientation in enumerate(reference_orientations):
@@ -124,7 +342,6 @@ class HeadOrientationNode:
             for i, orientation in enumerate(input_orientations):
                 if i in used_indices:
                     continue
-
                 diff = sum((a - b) ** 2 for a, b in zip(ref_orientation, orientation)) ** 0.5
                 if diff < best_diff:
                     best_diff = diff
@@ -144,10 +361,14 @@ class HeadOrientationNode:
                         print(f"{Colors.YELLOW}[SORT] No match found for reference {ref_idx+1}, using input image {i+1}{Colors.ENDC}")
                         break
 
-        while len(sorted_indices) < len(reference_orientations):
+        while len(sorted_indices) < len(reference_orientations) and sorted_indices:
             sorted_indices.append(sorted_indices[-1])
             sorted_orientations.append(sorted_orientations[-1])
             print(f"{Colors.YELLOW}[SORT] Not enough input images, repeating last image (index {sorted_indices[-1]+1}){Colors.ENDC}")
+
+        if not sorted_indices:
+            print(f"{Colors.RED}[SORT] No input images to sort, returning original batch{Colors.ENDC}")
+            return images, []
 
         print(f"{Colors.BLUE}[SORT] Final sorted indices: {sorted_indices}{Colors.ENDC}")
         sorted_images = images[sorted_indices]
@@ -155,12 +376,14 @@ class HeadOrientationNode:
         return sorted_images, sorted_orientations
 
     def format_orientation_data(self, orientations):
-        data_output = ""
-        for x, y, z in orientations:
-            data_output += f"[{x:.2f},{y:.2f},{z:.2f}]\n"
-        return data_output
+        return "".join(f"[{x:.2f},{y:.2f},{z:.2f}]\n" for x, y, z in orientations)
 
-# This line is necessary for ComfyUI to recognize and load your custom node
+
+# Mappings used by ComfyUI to discover and load custom nodes
 NODE_CLASS_MAPPINGS = {
-    "HeadOrientationNode": HeadOrientationNode
+    "HeadOrientationNode": HeadOrientationNode,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "HeadOrientationNode": "Head Orientation Node - by PabloGFX",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "head-orientation-node"
 description = "A custom node for ComfyUI that analyzes and sorts images based on head orientation using MediaPipe. It detects facial landmarks, calculates head pose, and intelligently sorts images for enhanced AI image processing workflows."
-version = "1.0.11"
+version = "1.1.0"
 license = {file = "LICENSE"}
-dependencies  = ["numpy>=1.19.3", "opencv-python>=4.5.5.64", "mediapipe>=0.8.9.1", "Pillow>=8.3.1", "torch>=1.9.0"] # Filled in from requirements.txt
+dependencies  = ["numpy>=1.19.3", "opencv-python>=4.5.5.64", "mediapipe>=0.10.0", "Pillow>=8.3.1", "torch>=1.9.0"]
 
 [project.urls]
 Repository = "https://github.com/lazniak/Head-Orientation-Node-for-ComfyUI---by-PabloGFX"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.19.3
 opencv-python>=4.5.5.64
-mediapipe>=0.8.9.1
+mediapipe>=0.10.0
 Pillow>=8.3.1
 torch>=1.9.0


### PR DESCRIPTION
The legacy `mediapipe.solutions.face_mesh` API has been removed from the slim mediapipe builds shipped with the ComfyUI Windows portable (and from mediapipe >=0.11). The node now uses the new
`mediapipe.tasks.python.vision.FaceLandmarker` API and falls back to the legacy `solutions` API if it is still available, so the same code works on both old and new installations.

Highlights
- Dual-backend `_FaceDetector` adapter (Tasks API + legacy fallback).
- Automatic one-time download of the official Google-hosted `face_landmarker.task` model (~3.7 MB) into `models/`.
- Correct RGB handling (the legacy code unintentionally swapped R and B via an extra cv2.cvtColor call).
- Graceful handling of grayscale / RGBA inputs and safer batch sorting when no input images are provided.
- Backend mode is logged at init time for easier debugging.

Bumps mediapipe dependency floor to >=0.10 and project version to 1.1.0.